### PR TITLE
Fix MessageListView queryset typo

### DIFF
--- a/ResumeAPI/views.py
+++ b/ResumeAPI/views.py
@@ -33,7 +33,7 @@ class WorkExperienceDetailsView(generics.RetrieveAPIView):
     serializer_class = WorkExperienceSerializer
 
 class MessageListView(generics.ListAPIView):
-    queyset = Message.objects.all()
+    queryset = Message.objects.all()
     serializer_class = MessageSerializer
     permission_classes = [IsAuthenticated, IsAdminUser]
 class MessageCreateView(generics.CreateAPIView):


### PR DESCRIPTION
## Summary
- correct a typo in `MessageListView` queryset

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*