### PR TITLE
Fix request.user usage in permission check

### DIFF
--- a/ResumeAPI/permissions.py
+++ b/ResumeAPI/permissions.py
@@ -2,7 +2,7 @@ from rest_framework.permissions import BasePermission
 from django.contrib.auth.models import Group, User
 class IsAdminUser(BasePermission):
     def has_permission(self, request, view):
-        user = request.get('user')
+        user = request.user
         if not user:
             return False
         adminGroup = Group.objects.get(name='Admin')


### PR DESCRIPTION
## Summary
- fix IsAdminUser to access `request.user` directly

## Testing
- `python -m py_compile ResumeAPI/permissions.py`
