### PR TITLE
Fix list_filter tuple in SkillCategoryAdmin

### DIFF
--- a/ResumeAPI/admin.py
+++ b/ResumeAPI/admin.py
@@ -42,7 +42,7 @@ admin.site.register(Technology, TechnologyAdmin)
 class SkillCategoryAdmin(admin.ModelAdmin):
     list_display = ('id', 'category_name')
     search_fields = ('id', 'category_name')
-    list_filter = ('category_name')
+    list_filter = ('category_name',)
 admin.site.register(SkillCategory, SkillCategoryAdmin)
 class SkillAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'category')


### PR DESCRIPTION
## Summary
- fix tuple syntax for `list_filter` in `SkillCategoryAdmin`
- review other admin classes for similar issues

## Testing
- `python -m py_compile ResumeAPI/admin.py`
